### PR TITLE
Use CSS variable for header and footer background

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -7,7 +7,7 @@
 <style scoped>
 footer {
   margin: 20px auto;
-  background-color: #8d549d;
+  background-color: var(--bg);
   font-size: 0.8rem;
   text-align: center;
   padding: 10px 10px;

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -11,7 +11,7 @@
 <style scoped>
 header {
   margin: 20px auto;
-  background-color: #8d549d;
+  background-color: var(--bg);
   padding: 10px 10px;
   border-radius: 6px;
 }


### PR DESCRIPTION
Replaced hardcoded background color in Header and Footer components with the CSS variable --bg for improved theme flexibility.